### PR TITLE
added getServerInfo & listIndexes methods

### DIFF
--- a/source/includes/_kuzzleObject.md
+++ b/source/includes/_kuzzleObject.md
@@ -336,6 +336,287 @@ Available options:
 |---------------|---------|----------------------------------------|---------|
 | ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
 
+
+## getServerInfo
+
+```js
+// Using callbacks (NodeJS or Web Browser)
+kuzzle.getServerInfo(function (err, stats) {
+  // ...
+});
+
+// Using promises (NodeJS only)
+kuzzle.getServerInfoPromise()
+  .then(infos => {
+  // ...  
+  });
+```
+
+> Returns a JSON Object containing the server informations:
+
+```json
+{
+  "kuzzle": {
+    "api": {
+      "routes": {
+        "admin": [
+          "deleteCollection",
+          "putMapping",
+          "getMapping",
+          "getStats",
+          "getLastStats",
+          "getAllStats",
+          "truncateCollection",
+          "putRole",
+          "deleteIndexes",
+          "createIndex",
+          "deleteIndex",
+          "removeRooms"
+        ],
+        "auth": [
+          "login"
+        ],
+        "bulk": [
+          "import"
+        ],
+        "read": [
+          "search",
+          "get",
+          "count",
+          "listCollections",
+          "now",
+          "listIndexes",
+          "serverInfo"
+        ],
+        "subscribe": [
+          "on",
+          "join",
+          "off",
+          "count",
+          "list"
+        ],
+        "write": [
+          "create",
+          "publish",
+          "createOrUpdate",
+          "update",
+          "delete",
+          "deleteByQuery",
+          "createCollection"
+        ]
+      },
+      "version": "1.0"
+    },
+    "memoryUsed": 99901440,
+    "nodeVersion": "v4.2.1",
+    "plugins": {
+      "kuzzle-plugin-auth-passport-local": {
+        "activated": true,
+        "hooks": [
+          "auth:loadStrategies"
+        ],
+        "name": "kuzzle-plugin-auth-passport-local"
+      },
+      "kuzzle-plugin-logger": {
+        "activated": true,
+        "hooks": [
+          "log:silly",
+          "log:verbose",
+          "log:info",
+          "log:debug",
+          "log:warn",
+          "log:error",
+          "data:*",
+          "subscription:*",
+          "websocket:*",
+          "prepare:*",
+          "cleanDb:done",
+          "cleanDb:error",
+          "server:*",
+          "rabbit:started",
+          "rabbit:error",
+          "rabbit:stopped",
+          "internalBroker:*",
+          "room:new",
+          "room:remove",
+          "workerGroup:loaded",
+          "profiling:*"
+        ],
+        "name": "kuzzle-plugin-logger",
+        "version": "1.0.6"
+      },
+      "kuzzle-plugin-socketio": {
+        "activated": true,
+        "hooks": [
+          "protocol:broadcast",
+          "protocol:joinChannel",
+          "protocol:leaveChannel"
+        ],
+        "name": "kuzzle-plugin-socketio",
+        "version": "1.0.4"
+      }
+    },
+    "system": {
+      "cpus": [
+        {
+          "model": "Intel(R) Core(TM) i5-4310M CPU @ 2.70GHz",
+          "speed": 800,
+          "times": {
+            "idle": 8859265400,
+            "irq": 500,
+            "nice": 4325300,
+            "sys": 115447100,
+            "user": 497028200
+          }
+        },
+        {
+          "model": "Intel(R) Core(TM) i5-4310M CPU @ 2.70GHz",
+          "speed": 2701,
+          "times": {
+            "idle": 8848628800,
+            "irq": 400,
+            "nice": 3648100,
+            "sys": 115458300,
+            "user": 495154300
+          }
+        },
+        {
+          "model": "Intel(R) Core(TM) i5-4310M CPU @ 2.70GHz",
+          "speed": 1300,
+          "times": {
+            "idle": 8875594600,
+            "irq": 4200,
+            "nice": 3956800,
+            "sys": 98348100,
+            "user": 538083800
+          }
+        },
+        {
+          "model": "Intel(R) Core(TM) i5-4310M CPU @ 2.70GHz",
+          "speed": 2701,
+          "times": {
+            "idle": 8801022600,
+            "irq": 0,
+            "nice": 3946300,
+            "sys": 97387200,
+            "user": 552344400
+          }
+        }
+      ],
+      "memory": {
+        "free": 1651486720,
+        "total": 16729739264
+      }
+    },
+    "uptime": "161016.824s",
+    "version": "0.9.2"
+  },
+  "services": {
+    "internalCache": {
+      "memoryPeak": "4.88M",
+      "memoryUsed": "4.88M",
+      "mode": "standalone",
+      "type": "redis",
+      "version": "3.0.2"
+    },
+    "readEngine": {
+      "api": "1.7",
+      "lucene": "4.10.4",
+      "nodes": {
+        "count": {
+          "client": 0,
+          "data_only": 0,
+          "master_data": 1,
+          "master_only": 0,
+          "total": 1
+        },
+        "fs": {
+          "available": "5.5gb",
+          "available_in_bytes": 5996474368,
+          "free": "7.4gb",
+          "free_in_bytes": 8013250560,
+          "total": "36.5gb",
+          "total_in_bytes": 39237341184
+        },
+        "jvm": {
+          "max_uptime": "1.9d",
+          "max_uptime_in_millis": 171087444,
+          "mem": {
+            "heap_max": "990.7mb",
+            "heap_max_in_bytes": 1038876672,
+            "heap_used": "51.8mb",
+            "heap_used_in_bytes": 54394592
+          },
+          "threads": 75,
+          "versions": [
+            {
+              "count": 1,
+              "version": "1.8.0_66-internal",
+              "vm_name": "OpenJDK 64-Bit Server VM",
+              "vm_vendor": "Oracle Corporation",
+              "vm_version": "25.66-b01"
+            }
+          ]
+        },
+        "os": {
+          "available_processors": 4,
+          "cpu": [
+            {
+              "cache_size": "3kb",
+              "cache_size_in_bytes": 3072,
+              "cores_per_socket": 16,
+              "count": 1,
+              "mhz": 2701,
+              "model": "Core(TM) i5-4310M CPU @ 2.70GHz",
+              "total_cores": 4,
+              "total_sockets": 4,
+              "vendor": "Intel"
+            }
+          ],
+          "mem": {
+            "total": "15.5gb",
+            "total_in_bytes": 16729739264
+          }
+        },
+        "plugins": [],
+        "process": {
+          "cpu": {
+            "percent": 0
+          },
+          "open_file_descriptors": {
+            "avg": 190,
+            "max": 190,
+            "min": 190
+          }
+        },
+        "versions": [
+          "1.5.2"
+        ]
+      },
+      "spaceUsed": "14.5kb",
+      "status": "red",
+      "type": "elasticsearch",
+      "version": "1.5.2"
+    },
+    { "etc." }
+  }
+}
+```
+
+Returns information about Kuzzle, its plugins and active services.
+
+#### getServerInfo([options])
+
+| Arguments | Type | Description |
+|---------------|---------|----------------------------------------|
+| ``options`` | JSON Object | Optional parameters |
+
+Available options:
+
+| Option | Type | Description | Default |
+|---------------|---------|----------------------------------------|---------|
+| ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
+
 ## getStatistics
 
 > Without argument, returns the last statistic frame in an array:
@@ -454,20 +735,20 @@ Available options:
 
 ```js
 // Using callbacks (NodeJS or Web Browser)
-kuzzle.listCollections({type: 'stored'}, function (err, collections) {
+kuzzle.listCollections('index', {type: 'stored'}, function (err, collections) {
   // ...
 });
 
 // Using promises (NodeJS only)
 kuzzle
-  .listCollectionsPromise({type: 'stored'})
+  .listCollectionsPromise('index', {type: 'stored'})
   .then(collections => {
     // ...
   });
 ```
 
 ```java
-kuzzle.listCollections(new ResponseListener() {
+kuzzle.listCollections("index", new ResponseListener() {
   @Override
   public void onSuccess(JSONObject object) {
     // ...
@@ -489,12 +770,13 @@ kuzzle.listCollections(new ResponseListener() {
 }
 ```
 
-Returns the list of known persisted data collections.
+Returns the list of known data collections contained in a specified index.
 
-#### listCollections([options])
+#### listCollections([index], [options])
 
 | Arguments | Type | Description |
 |---------------|---------|----------------------------------------|
+| ``index`` | string | Index containing the collections to be listed |
 | ``options`` | JSON Object | Optional parameters |
 
 Available options:
@@ -505,7 +787,58 @@ Available options:
 | ``type`` | string | Get either ``stored`` collections or ``realtime`` ones. By default, list ``all`` collections | ``all`` |
 
 
+If no `index` argument is provided, the `defaultIndex` property is used. If no default index is found, this method throws an error.
+
+## listIndexes
+
+```js
+// Using callbacks (NodeJS or Web Browser)
+kuzzle.listIndexes(function (err, collections) {
+  // ...
+});
+
+// Using promises (NodeJS only)
+kuzzle
+  .listIndexesPromise()
+  .then(indexes => {
+    // ...
+  });
+```
+
+> Result:
+
+```json
+[ 'index', 'another index', '...']
+```
+
+Returns the list of indexes stored in Kuzzle.
+
+#### listIndexes([options])
+
+| Arguments | Type | Description |
+|---------------|---------|----------------------------------------|
+| ``options`` | JSON Object | Optional parameters |
+
+Available options:
+
+| Option | Type | Description | Default |
+|---------------|---------|----------------------------------------|---------|
+| ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
+
+
 ## login
+
+```js
+kuzzle.login("local", {username: "username", password: "password"}, "1h");
+```
+
+```java
+kuzzle.login("local", "username", "password", "1h");
+```
+
+Log a user according to the strategy and credentials.
+
+#### login([options])
 
 | Arguments | Type | Description |
 |---------------|---------|----------------------------------------|
@@ -519,16 +852,6 @@ Available options:
 | ``loginCredentials`` | JSON object | The credentials |
 | ``loginExpiresIn`` | string | Expire time | ``1h``
 
-
-```js
-kuzzle.login("local", {username: "username", password: "password"}, "1h");
-```
-
-```java
-kuzzle.login("local", "username", "password", "1h");
-```
-
-Log a user according to the strategy and credentials.
 
 ## logout
 


### PR DESCRIPTION
- documented the new  `Kuzzle.getServerInfo` method
- document the new `Kuzzle.listIndexes` method
- added a new optional `index` argument to the `Kuzzle.listCollections` method. If no `index` is specified, takes the `defaultIndex` property. If no default index is found, throws an error.