### PR TITLE
fixed documentation issues

### DIFF
--- a/source/includes/_kuzzleDataCollection.md
+++ b/source/includes/_kuzzleDataCollection.md
@@ -43,6 +43,7 @@ var dataCollection = kuzzle.dataCollectionFactory('index', 'collection');
 
 ```js
 var filter = {
+  filter: {
     and: [
       {
         terms: {
@@ -63,6 +64,7 @@ var filter = {
         }
       }
     ]
+  }
 };
 
 kuzzle
@@ -86,33 +88,35 @@ kuzzle
 
 ```java
 JSONObject filter = new JSONObject()
-  .put("and", new JSONArray()
-    .put(
-      new JSONObject().put("terms",
-        new JSONObject().put("status",
-          new JSONArray()
-            .put("idle")
-            .put("wantToHire")
-            .put("toHire")
-            .put("riding")
+  .put("filter", new JSONObject()
+    .put("and", new JSONArray()
+      .put(
+        new JSONObject().put("terms",
+          new JSONObject().put("status",
+            new JSONArray()
+              .put("idle")
+              .put("wantToHire")
+              .put("toHire")
+              .put("riding")
+          )
         )
       )
-    )
-    .put(
-      new JSONObject().put("terms",
-        new JSONObject()
-          .put("type", new JSONArray().put("cab"))
+      .put(
+        new JSONObject().put("terms",
+          new JSONObject()
+            .put("type", new JSONArray().put("cab"))
+        )
       )
-    )
-    .put(
-      new JSONObject().put("geo_distance",
-        new JSONObject()
-          .put("distance", "10km")
-          .put("pos",
-            new JSONObject()
-              .put("lat", "48.8566140")
-              .put("lon", "2.352222")
-          )
+      .put(
+        new JSONObject().put("geo_distance",
+          new JSONObject()
+            .put("distance", "10km")
+            .put("pos",
+              new JSONObject()
+                .put("lat", "48.8566140")
+                .put("lon", "2.352222")
+            )
+        )
       )
     )
   );
@@ -1049,6 +1053,9 @@ var room =
     .dataCollectionFactory('index', 'collection')
     .subscribe({term: {title: 'foo'}}, function (error, result) {
       // called each time a new notification on this filter is received
+
+      // check the KuzzleRoom/Notifications section of this documentation
+      // to get notification examples
     };
 ```
 
@@ -1091,6 +1098,9 @@ kuzzle
     @Override
     public void onSuccess(KuzzleNotificationResponse object) {
       // called each time a new notification on this filter is received
+
+      // check the KuzzleRoom/Notifications section of this documentation
+      // to get notification examples
     }
 
     @Override

--- a/source/includes/_kuzzleDocument.md
+++ b/source/includes/_kuzzleDocument.md
@@ -269,9 +269,7 @@ Changes made by this function won't be applied until the <code>save</code> metho
 Replaces the current content with new data.  
 This is a helper function returning itself, allowing to easily chain calls.
 
-#### setContent(data)
-
-#### setContent(data, replace)
+#### setContent(data, [replace])
 
 | Arguments | Type | Description |
 |---------------|---------|----------------------------------------|

--- a/source/includes/_kuzzleObject.md
+++ b/source/includes/_kuzzleObject.md
@@ -84,6 +84,7 @@ If the `connect` option is set to `manual`, the callback will be called after th
 | ``autoResubscribe`` | boolean | Automatically renew all subscriptions on a ``reconnected`` event | get/set |
 | ``defaultIndex`` | string | Kuzzle's default index to use | get |
 | ``headers`` | JSON object | Common headers for all sent documents. | get/set |
+| ``jwtToken`` | string | Token used in requests for authentication. | get/set |
 | ``metadata`` | JSON object | Common metadata, will be sent to all future requests | get/set |
 | ``offlineQueue`` | JSON object | Contains the queued requests during offline mode | get/set |
 | ``offlineQueueLoader`` | function | Called before dequeuing requests after exiting offline mode, to add items at the beginning of the offline queue | get/set |

--- a/source/includes/_kuzzleRoom.md
+++ b/source/includes/_kuzzleRoom.md
@@ -198,6 +198,9 @@ Resolves to a `integer` containing the number of users subscribing to this room.
 ```js
 room.renew({terms: {field: ['some', 'new', 'filter']}}, function (err, res) {
   // called each time a change is detected on documents matching this filter
+
+  // check the KuzzleRoom/Notifications section of this documentation
+  // to get notification examples
 });
 ```
 
@@ -238,6 +241,9 @@ room.renew(filters, new KuzzleResponseListener<KuzzleNotificationResponse>() {
  @Override
  public void onSuccess(KuzzleNotificationResponse result) throws Exception {
    // called each time a change is detected on documents matching this filter
+
+   // check the KuzzleRoom/Notifications section of this documentation
+   // to get notification examples
  }
 
  @Override

--- a/source/includes/security/_kuzzleProfile.md
+++ b/source/includes/security/_kuzzleProfile.md
@@ -258,7 +258,7 @@ role
 JSONObject updateContent = new JSONObject()
   .put("profile", "new profile");
 
-user.update(new KuzzleResponseListener<KuzzleProfile>() {
+user.update(updateContent, new KuzzleResponseListener<KuzzleProfile>() {
   @Override
   public void onSuccess(KuzzleProfile updatedProfile) {
 
@@ -273,10 +273,11 @@ user.update(new KuzzleResponseListener<KuzzleProfile>() {
 
 Performs a partial content update on this object.
 
-#### update([options], [callback])
+#### update(content, [options], [callback])
 
 | Arguments | Type | Description |
 |---------------|---------|----------------------------------------|
+| ``content`` | JSON Object | Profile content |
 | ``options`` | JSON Object | Optional parameters |
 | ``callback`` | function | Optional callback handling the response |
 

--- a/source/includes/security/_kuzzleProfile.md
+++ b/source/includes/security/_kuzzleProfile.md
@@ -23,7 +23,7 @@ var role = kuzzle.security.profileFactory('myprofile', profileDefinition);
 JSONObject roles = new JSONObject()
   .put("roles", new JSONArray()
     .put("some role")
-    .put("some othe role")
+    .put("some other role")
   );
 
 KuzzleProfile profile = new KuzzleProfile(kuzzle.security, "profileId", roles);
@@ -434,12 +434,14 @@ profile.setRoles({"role1 ID", "role2 ID", "role3 ID"});
 
 Replaces the roles associated to the profile.
 
+#### setRoles(roleNameArray)
 
-#### setRoles(roles)
+#### setRoles(kuzzleRoleArray)
 
 | Arguments | Type | Description |
 |---------------|---------|----------------------------------------|
-| ``roles`` | array | Array of string or KuzzleRole objects |
+| ``roleNameArray`` | array of strings | Names of the roles to add |
+| ``kuzzleRoleArray`` | array of `KuzzleRole` objects | `KuzzleRole` objects to add |
 
 #### Return value
 

--- a/source/includes/security/_kuzzleRole.md
+++ b/source/includes/security/_kuzzleRole.md
@@ -168,7 +168,7 @@ JSONObject updateContent = new JSONObject()
     )
   );
 
-role.update(new KuzzleResponseListener<KuzzleRole>() {
+role.update(updateContent, new KuzzleResponseListener<KuzzleRole>() {
   @Override
   public void onSuccess(KuzzleRole updatedRole) {
 
@@ -198,10 +198,11 @@ To get some more detailed information on the expected role definition, please re
 To get some more detailed information about Kuzzle's user management model, please refer to [Kuzzle's security documentation](https://github.com/kuzzleio/kuzzle/blob/master/docs/security/).
 
 
-#### update([options], [callback])
+#### update(content, [options], [callback])
 
 | Arguments | Type | Description |
 |---------------|---------|----------------------------------------|
+| ``content`` | JSON Object | New role content |
 | ``options`` | JSON Object | Optional parameters |
 | ``callback`` | function | Optional callback handling the response |
 

--- a/source/includes/security/_kuzzleSecurity.md
+++ b/source/includes/security/_kuzzleSecurity.md
@@ -693,7 +693,12 @@ var profile = kuzzle.security.profileFactory('myprofile', profileDefinition);
 ```
 
 ```java
-JSONArray profileDefinition = new JSONArray().put("myrole").put("default");
+JSONObject profileDefinition = new JSONObject()
+  .put("roles", new JSONArray()
+    .put("some role")
+    .put("some other role")
+  );
+
 KuzzleProfile profile = kuzzle.security.profileFactory("myprofile", profileDefinition);
 ```
 
@@ -1121,6 +1126,7 @@ kuzzle
   });
 ```
 
+#### updateProfile(id, content, [options], [callback])
 
 Performs a partial update on an existing profile.
 
@@ -1129,7 +1135,7 @@ Performs a partial update on an existing profile.
 | ``id`` | string | Unique role identifier |
 | ``content`` | JSON Object | A plain javascript object representing the profile |
 | ``options`` | string | (Optional) Optional arguments |
-| ``callback`` | function | Callback handling the response |
+| ``callback`` | function | (Optional) Callback handling the response |
 
 Available options:
 
@@ -1191,6 +1197,7 @@ kuzzle
   });
 ```
 
+#### updateRole(id, content, [options], [callback])
 
 Performs a partial update on an existing role.
 
@@ -1199,7 +1206,7 @@ Performs a partial update on an existing role.
 | ``id`` | string | Unique role identifier |
 | ``content`` | JSON Object | A plain javascript object representing the role |
 | ``options`` | string | (Optional) Optional arguments |
-| ``callback`` | function | Callback handling the response |
+| ``callback`` | function | (Optional) Callback handling the response |
 
 Available options:
 
@@ -1257,6 +1264,7 @@ kuzzle
   });
 ```
 
+#### updateUser(id, content, [options], [callback])
 
 Performs a partial update on an existing user.
 
@@ -1265,7 +1273,7 @@ Performs a partial update on an existing user.
 | ``id`` | string | Unique role identifier |
 | ``content`` | JSON Object | A plain javascript object representing the user |
 | ``options`` | string | (Optional) Optional arguments |
-| ``callback`` | function | Callback handling the response |
+| ``callback`` | function | (Optional) Callback handling the response |
 
 Available options:
 

--- a/source/includes/security/_kuzzleUser.md
+++ b/source/includes/security/_kuzzleUser.md
@@ -232,7 +232,7 @@ JSONObject updateContent = new JSONObject()
   .put("firstname", "My Name Is")
   .put("lastname", "Jonas");
 
-user.update(new KuzzleResponseListener<KuzzleUser>() {
+user.update(updateContent, new KuzzleResponseListener<KuzzleUser>() {
   @Override
   public void onSuccess(KuzzleUser updatedUser) {
 
@@ -247,10 +247,11 @@ user.update(new KuzzleResponseListener<KuzzleUser>() {
 
 Performs a partial content update on this object.
 
-#### update([options], [callback])
+#### update(content, [options], [callback])
 
 | Arguments | Type | Description |
 |---------------|---------|----------------------------------------|
+| ``content`` | JSON Object | User content |
 | ``options`` | JSON Object | Optional parameters |
 | ``callback`` | function | Optional callback handling the response |
 

--- a/source/includes/security/_kuzzleUser.md
+++ b/source/includes/security/_kuzzleUser.md
@@ -389,12 +389,15 @@ Updating an user will have no impact until the <code>save</code> method is calle
 
 Replace the profile associated to the user
 
-#### setProfile(profile)
+#### setProfile(profileId)
+
+#### setProfile(kuzzleProfile)
 
 | Arguments | Type | Description |
 |---------------|---------|----------------------------------------|
-| ``profile`` | string OR KuzzleProfile  | Profile identifier or a KuzzleProfile instance |
+| ``profileId`` | string | Profile ID |
+| ``kuzzleProfile`` | KuzzleProfile | An instanciated KuzzleProfile object |
 
 #### Return value
 
-Returns the `KuzzleRole` object.
+Returns the `KuzzleUser` object.


### PR DESCRIPTION

* Added missing `jwtToken` property in the `Kuzzle` object
* Added a comment in `KuzzleDataCollection.subscribe` and in `KuzzleRoom.renew` methods pointing to the notifications documentation
* Fixed `KuzzleDataCollection.advancedSearch` example for both Javascript and Android SDKs
* Fixed `KuzzleUser.setProfile` return value
* Made `KuzzleUser.setProfile` prototypes explicit
* Made `KuzzleProfile.setRoles` prototypes explicit
* Fixed `KuzzleSecurity.profileFactory` Android example
* Added missing prototype to the `KuzzleSecurity.update*` methods
* Fixed `KuzzleUser.update` documentation and Android example
* Fixed `KuzzleProfile.update` documentation and Android example
* Fixed `KuzzleRole.update` documentation and Android example
* Normalized `KuzzleDocument.setContent` prototype
