### PR TITLE
KUZ-523 : Add updateSelf documentation

### DIFF
--- a/source/includes/_kuzzleObject.md
+++ b/source/includes/_kuzzleObject.md
@@ -1410,7 +1410,7 @@ Set the default data index. Has the same effect than the `defaultIndex` construc
 
 Returns the `Kuzzle` object to allow chaining.
 
-## selfUpdate
+## updateSelf
 
 ```js
 var newContent = {
@@ -1421,13 +1421,13 @@ var newContent = {
 
 // Using callbacks (NodeJS or Web Browser)
 kuzzle
-  .selfUpdate(newContent, function (err, updatedUserId) {
+  .updateSelf(newContent, function (err, updatedUserId) {
 
   });
 
 // Using promises (NodeJS)
 kuzzle
-  .selfUpdatePromise(newContent)
+  .updateSelfPromise(newContent)
   .then(updatedUserId => {
 
   });
@@ -1439,7 +1439,7 @@ JSONObject newContent = new JSONObject()
   .put("lastname", "Jonas");
 
 kuzzle
-  .selfUpdate(newContent, new KuzzleResponseListener<KuzzleUser>() {
+  .updateSelf(newContent, new KuzzleResponseListener<KuzzleUser>() {
     @Override
     public void onSuccess(KuzzleUser user) {
 
@@ -1452,7 +1452,7 @@ kuzzle
   });
 ```
 
-#### selfUpdate(content, [options], [callback])
+#### updateSelf(content, [options], [callback])
 
 Performs a partial update on the current user.
 

--- a/source/includes/_kuzzleObject.md
+++ b/source/includes/_kuzzleObject.md
@@ -1421,14 +1421,14 @@ var newContent = {
 
 // Using callbacks (NodeJS or Web Browser)
 kuzzle
-  .updateSelf(newContent, function (err, updatedUserId) {
+  .updateSelf(newContent, function (err, updatedUser) {
 
   });
 
 // Using promises (NodeJS)
 kuzzle
   .updateSelfPromise(newContent)
-  .then(updatedUserId => {
+  .then(updatedUser => {
 
   });
 ```
@@ -1439,9 +1439,9 @@ JSONObject newContent = new JSONObject()
   .put("lastname", "Jonas");
 
 kuzzle
-  .updateSelf(newContent, new KuzzleResponseListener<KuzzleUser>() {
+  .updateSelf(newContent, new KuzzleResponseListener<JSONObject>() {
     @Override
-    public void onSuccess(KuzzleUser user) {
+    public void onSuccess(JSONObject user) {
 
     }
 
@@ -1470,7 +1470,7 @@ Available options:
 
 #### Callback response
 
-Resolves to the updated user ID
+Resolves to the updated user plain object.
 
 
 ## setHeaders

--- a/source/includes/_kuzzleObject.md
+++ b/source/includes/_kuzzleObject.md
@@ -1410,6 +1410,68 @@ Set the default data index. Has the same effect than the `defaultIndex` construc
 
 Returns the `Kuzzle` object to allow chaining.
 
+## selfUpdate
+
+```js
+var newContent = {
+  firstname: 'My Name Is',
+  lastname: 'Jonas'
+};
+
+
+// Using callbacks (NodeJS or Web Browser)
+kuzzle
+  .selfUpdate(newContent, function (err, updatedUserId) {
+
+  });
+
+// Using promises (NodeJS)
+kuzzle
+  .selfUpdatePromise(newContent)
+  .then(updatedUserId => {
+
+  });
+```
+
+```java
+JSONObject newContent = new JSONObject()
+  .put("firstname", "My Name Is")
+  .put("lastname", "Jonas");
+
+kuzzle
+  .selfUpdate(newContent, new KuzzleResponseListener<KuzzleUser>() {
+    @Override
+    public void onSuccess(KuzzleUser user) {
+
+    }
+
+    @Override
+    public void onError(JSONObject error) {
+
+    }
+  });
+```
+
+#### selfUpdate(content, [options], [callback])
+
+Performs a partial update on the current user.
+
+| Arguments | Type | Description |
+|---------------|---------|----------------------------------------|
+| ``content`` | JSON Object | A plain javascript object representing the user |
+| ``options`` | string | (Optional) Optional arguments |
+| ``callback`` | function | (Optional) Callback handling the response |
+
+Available options:
+
+| Filter | Type | Description | Default |
+|---------------|---------|----------------------------------------|---------|
+| ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
+
+#### Callback response
+
+Resolves to the updated user ID
+
 
 ## setHeaders
 

--- a/source/includes/security/_kuzzleSecurity.md
+++ b/source/includes/security/_kuzzleSecurity.md
@@ -1231,7 +1231,7 @@ var newContent = {
 // Using callbacks (NodeJS or Web Browser)
 kuzzle
   .security
-  .updateUser("User ID", newContent, function (err, updatedUserId) {
+  .updateUser("User ID", newContent, function (err, updatedUser) {
 
   });
 
@@ -1239,7 +1239,7 @@ kuzzle
 kuzzle
   .security
   .updateUserPromise("User ID", newContent)
-  .then(updatedUserId => {
+  .then(updatedUser => {
 
   });
 ```
@@ -1283,7 +1283,7 @@ Available options:
 
 #### Callback response
 
-Resolves to the updated user ID
+Resolves to the updated user's `KuzzleUser`.
 
 ## userFactory
 

--- a/source/includes/security/_kuzzleSecurity.md
+++ b/source/includes/security/_kuzzleSecurity.md
@@ -1231,7 +1231,7 @@ var newContent = {
 // Using callbacks (NodeJS or Web Browser)
 kuzzle
   .security
-  .updateUser("User ID", newContent, function (err, updatedUser) {
+  .updateUser("User ID", newContent, function (err, updatedUserId) {
 
   });
 
@@ -1239,7 +1239,7 @@ kuzzle
 kuzzle
   .security
   .updateUserPromise("User ID", newContent)
-  .then(updatedUser => {
+  .then(updatedUserId => {
 
   });
 ```


### PR DESCRIPTION
* :warning: Open question : It seams there is a mismatch in `security.updateUser` : in JS (and doc), the result resolves to the user ID, but in Android, it seams it resolves to a `KuzzleUser`; I reproduced this behavior for now in JS `updateSelf`, so I documented it accordingly.
* Add `updateSelf` documentation