### PR TITLE
fixes updateXXX and deleteXXX inconsistencies

### DIFF
--- a/source/includes/_kuzzleDataCollection.md
+++ b/source/includes/_kuzzleDataCollection.md
@@ -868,10 +868,6 @@ Available options:
 | ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
 
 
-#### Return value
-
-Returns the `KuzzleDataCollection` object to allow chaining.
-
 #### Callback response
 
 Resolves to an `array` containing the deleted document IDs.

--- a/source/includes/_kuzzleDocument.md
+++ b/source/includes/_kuzzleDocument.md
@@ -163,13 +163,9 @@ Available options:
 | ``metadata`` | JSON Object | Additional information passed to notifications to other users | ``null`` |
 | ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
 
-#### Return value
-
-Returns this `KuzzleDocument` object to allow chaining.
-
 #### Callback response
 
-Resolves to this `KuzzleDocument` object once the document has been deleted in Kuzzle.
+Resolves to the deleted document ID
 
 
 ## publish

--- a/source/includes/security/_kuzzleSecurity.md
+++ b/source/includes/security/_kuzzleSecurity.md
@@ -1824,7 +1824,7 @@ Available options:
 
 #### Callback response
 
-Resolves to the updated profile ID
+Resolves to an updated `KuzzleProfile` object
 
 ## updateRole
 
@@ -1941,7 +1941,7 @@ Available options:
 
 #### Callback response
 
-Resolves to the updated role ID
+Resolves to an updated `KuzzleRole` object
 
 
 ## updateUser
@@ -2048,7 +2048,7 @@ Available options:
 
 #### Callback response
 
-Resolves to the updated user's `KuzzleUser`.
+Resolves to an updated `KuzzleUser` object
 
 ## userFactory
 


### PR DESCRIPTION
- all `delete` methods now stop the call chain, returning nothing
- all `delete` methods now return the ID of the deleted document/user/profile/role, instead of an object
- all `update` methods now return an up-to-date document/user/profile/role object
